### PR TITLE
Adjustments in GameSession

### DIFF
--- a/config/crd/bases/gamesession.kube-game.shiftweek.poc_gamesessions.yaml
+++ b/config/crd/bases/gamesession.kube-game.shiftweek.poc_gamesessions.yaml
@@ -81,6 +81,13 @@ spec:
                 enum:
                   - p1
                   - p2
+              isSetup:
+                type: boolean
+                default: false
+              p1KubeConfig:
+                type: string
+              p2KubeConfig:
+                type: string
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true

--- a/roles/gamesession/tasks/main.yml
+++ b/roles/gamesession/tasks/main.yml
@@ -1,7 +1,17 @@
 ---
-# tasks file for GameSession
-- name: Create player
+- name: Setup players
   include_tasks: setup_player.yml
   loop: "{{ player_names }}"
   loop_control:
     loop_var: player_name
+  when: not _gamesession_kube_game_shiftweek_poc_gamesession.status.isSetup
+
+- name: Flag GameSession/{{ ansible_operator_meta.name }} as set up
+  operator_sdk.util.k8s_status:
+    api_version: gamesession.kube-game.shiftweek.poc/v1alpha1
+    kind: GameSession
+    name: "{{ ansible_operator_meta.name }}"
+    namespace: "{{ ansible_operator_meta.namespace }}"
+    status:
+      isSetup: true
+  when: not _gamesession_kube_game_shiftweek_poc_gamesession.status.isSetup

--- a/roles/gamesession/tasks/setup_player.yml
+++ b/roles/gamesession/tasks/setup_player.yml
@@ -1,5 +1,9 @@
 ---
-- name: Create {{ player_name }} namespace
+- name: Unique player name
+  set_fact:
+    player_full_name: '{{ ansible_operator_meta.name }}-{{ player_name }}'
+
+- name: Create {{ player_full_name }} namespace
   kubernetes.core.k8s:
     definition:
       kind: Namespace
@@ -9,68 +13,67 @@
         annotations:
           gamesession: '{{ ansible_operator_meta.name }}'
 
-- name: Create bind role for {{ player_name }}
+- name: Create bind role for {{ player_full_name }}
   kubernetes.core.k8s:
     definition:
       kind: RoleBinding
       metadata:
         name: role-binding-gamesession
-        namespace: '{{ ansible_operator_meta.name }}-{{ player_name }}'
+        namespace: '{{ player_full_name }}'
       subjects:
         - kind: User
-          name: '{{ player_name }}'
+          name: '{{ player_full_name }}'
           apiGroup: rbac.authorization.k8s.io
       roleRef:
         kind: ClusterRole
         name: gamesession-viewer-role
         apiGroup: rbac.authorization.k8s.io
 
-- name: Create bind role for {{ player_name }}
+- name: Create bind role for {{ player_full_name }}
   kubernetes.core.k8s:
     definition:
       kind: RoleBinding
       metadata:
         name: role-binding-playermove
-        namespace: '{{ ansible_operator_meta.name }}-{{ player_name }}'
+        namespace: '{{ player_full_name }}'
       subjects:
         - kind: User
-          name: '{{ player_name }}'
+          name: '{{ player_full_name }}'
           apiGroup: rbac.authorization.k8s.io
       roleRef:
         kind: ClusterRole
         name: playermove-viewer-role
         apiGroup: rbac.authorization.k8s.io
 
-- name: Create temporary directory to store {{ player_name }} credentials
+- name: Create temporary directory to store {{ player_full_name }} credentials
   ansible.builtin.tempfile:
     state: directory
     suffix: key
   register: tempdir
 
-- name: Generate an OpenSSL private key for {{ player_name }}
+- name: Generate an OpenSSL private key for {{ player_full_name }}
   community.crypto.openssl_privatekey:
-    path: "{{ tempdir.path }}/{{ player_name }}.key"
+    path: "{{ tempdir.path }}/{{ player_full_name }}.key"
     size: 2048
 
-- name: Generate an OpenSSL Certificate Signing Request {{ player_name }}
+- name: Generate an OpenSSL Certificate Signing Request {{ player_full_name }}
   community.crypto.openssl_csr:
-    path: "{{ tempdir.path }}/{{ player_name }}.csr"
-    privatekey_path: "{{ tempdir.path }}/{{ player_name }}.key"
-    common_name: '{{ player_name }}'
+    path: "{{ tempdir.path }}/{{ player_full_name }}.csr"
+    privatekey_path: "{{ tempdir.path }}/{{ player_full_name }}.key"
+    common_name: '{{ player_full_name }}'
     organization_name: players
 
-- name: Read OpenSSL Certificate Signing Request for {{ player_name }}
-  shell: cat "{{ tempdir.path }}/{{ player_name }}.csr"
+- name: Read OpenSSL Certificate Signing Request for {{ player_full_name }}
+  shell: cat "{{ tempdir.path }}/{{ player_full_name }}.csr"
   register: player_csr
 
-- name: Create a CertificateSigningRequest for {{ player_name }}
+- name: Create a CertificateSigningRequest for {{ player_full_name }}
   kubernetes.core.k8s:
     definition:
       kind: CertificateSigningRequest
       apiVersion: certificates.k8s.io/v1
       metadata:
-        name: '{{ player_name }}'
-        namespace: '{{ ansible_operator_meta.name }}-{{ player_name }}'
+        name: '{{ player_full_name }}'
       spec:
         request: '{{ player_csr.stdout | b64encode }}'
         signerName: kubernetes.io/kube-apiserver-client
@@ -78,28 +81,28 @@
         usages:
         - client auth
 
-- name: Approve CertificateSigningRequest for {{ player_name }}
-  shell: kubectl certificate approve '{{ player_name }}' -n '{{ ansible_operator_meta.name }}-{{ player_name }}'
+- name: Approve CertificateSigningRequest for {{ player_full_name }}
+  shell: kubectl certificate approve '{{ player_full_name }}'
 
-- name: Retrieve {{ player_name }} certificate
-  shell: kubectl get csr "{{ player_name }}" -o jsonpath='{.status.certificate}'
+- name: Retrieve {{ player_full_name }} certificate
+  shell: kubectl get csr '{{ player_full_name }}' -o jsonpath='{.status.certificate}'
   register: player_crt
 
-- name: Read {{ player_name }} key
-  shell: cat "{{ tempdir.path }}/{{ player_name }}.key"
+- name: Read {{ player_full_name }} key
+  shell: cat "{{ tempdir.path }}/{{ player_full_name }}.key"
   register: player_key
 
-- name: Render {{ player_name }} kubeconfig
+- name: Render {{ player_full_name }} kubeconfig
   set_fact:
     kubeconfig: '{{ lookup("template", "kubeconfig.j2") }}'
 
-- name: Store {{ player_name }} kubeconfig in GameSession/{{ ansible_operator_meta.name }} status
+- name: Store {{ player_full_name }} kubeconfig in GameSession/{{ ansible_operator_meta.name }} status
   operator_sdk.util.k8s_status:
     api_version: gamesession.kube-game.shiftweek.poc/v1alpha1
     kind: GameSession
     name: "{{ ansible_operator_meta.name }}"
     namespace: "{{ ansible_operator_meta.namespace }}"
-    status: '{ "{{ player_name }}-kubeconfig": {{ kubeconfig | to_json }} }'
+    status: '{ "{{ player_name }}KubeConfig": {{ kubeconfig | to_json }} }'
 
 - name: Cleanup temporary directory
   ansible.builtin.file:

--- a/roles/gamesession/templates/kubeconfig.j2
+++ b/roles/gamesession/templates/kubeconfig.j2
@@ -7,7 +7,7 @@ clusters:
 contexts:
 - context:
     cluster: kube-game-cluster
-    namespace: lobby
+    namespace: {{ player_full_name }}
     user: kube-game-player
   name: kube-game-player-context
 current-context: kube-game-player-context

--- a/roles/gamesession/vars/main.yml
+++ b/roles/gamesession/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 player_names:
-- "player-one"
-- "player-two"
+- "p1"
+- "p2"


### PR DESCRIPTION
- use name of gamesession + (p1|p2) to create namesapces and certificates (user name is global to the cluster)
- use a flag in status to setup the players only once
- Update the CRD witht the kubeconfig keys in status
- use p1/p2 to be consistent with the CRD API