### PR TITLE
fix gamesession permission

### DIFF
--- a/roles/gamesession/tasks/setup_player.yml
+++ b/roles/gamesession/tasks/setup_player.yml
@@ -13,14 +13,13 @@
         annotations:
           gamesession: '{{ ansible_operator_meta.name }}'
 
-- name: Create bind role for {{ player_full_name }}
+- name: Create bind gamesession viewer role for {{ player_full_name }}
   kubernetes.core.k8s:
     definition:
-      kind: RoleBinding
+      kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
-        name: role-binding-gamesession
-        namespace: '{{ player_full_name }}'
+        name: cluster-role-binding-gamesession
       subjects:
         - kind: User
           name: '{{ player_full_name }}'


### PR DESCRIPTION
Since the gamession object is located outside of the player's namespace,
we need to use a cluster wide binding.
